### PR TITLE
chore: update Terramate repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # asdf-terramate [![Build](https://github.com/martinlindner/asdf-terramate/actions/workflows/build.yml/badge.svg)](https://github.com/martinlindner/asdf-terramate/actions/workflows/build.yml) [![Lint](https://github.com/martinlindner/asdf-terramate/actions/workflows/lint.yml/badge.svg)](https://github.com/martinlindner/asdf-terramate/actions/workflows/lint.yml)
 
 
-[terramate](https://github.com/mineiros-io/terramate) plugin for the [asdf version manager](https://asdf-vm.com).
+[terramate](https://github.com/terramate-io/terramate) plugin for the [asdf version manager](https://asdf-vm.com).
 
 </div>
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/mineiros-io/terramate"
+GH_REPO="https://github.com/terramate-io/terramate"
 TOOL_NAME="terramate"
 TOOL_TEST="terramate --version"
 


### PR DESCRIPTION
The Terramate project is now located at https://github.com/terramate-io/terramate